### PR TITLE
fix(use-funnel): Fix NonEmptyArray type in model.ts.

### DIFF
--- a/packages/react/use-funnel/src/Funnel.tsx
+++ b/packages/react/use-funnel/src/Funnel.tsx
@@ -1,15 +1,15 @@
 /** @tossdocs-ignore */
 import { assert } from '@toss/assert';
 import { Children, isValidElement, ReactElement, ReactNode, useEffect } from 'react';
-import { NonEmptyArray } from './models';
+import { StepsType } from './models';
 
-export interface FunnelProps<Steps extends NonEmptyArray<string>> {
+export interface FunnelProps<Steps extends StepsType> {
   steps: Steps;
   step: Steps[number];
   children: Array<ReactElement<StepProps<Steps>>> | ReactElement<StepProps<Steps>>;
 }
 
-export const Funnel = <Steps extends NonEmptyArray<string>>({ steps, step, children }: FunnelProps<Steps>) => {
+export const Funnel = <Steps extends StepsType>({ steps, step, children }: FunnelProps<Steps>) => {
   const validChildren = Children.toArray(children)
     .filter(isValidElement)
     .filter(i => steps.includes((i.props as Partial<StepProps<Steps>>).name ?? '')) as Array<
@@ -23,13 +23,13 @@ export const Funnel = <Steps extends NonEmptyArray<string>>({ steps, step, child
   return <>{targetStep}</>;
 };
 
-export interface StepProps<Steps extends NonEmptyArray<string>> {
+export interface StepProps<Steps extends StepsType> {
   name: Steps[number];
   onEnter?: () => void;
   children: ReactNode;
 }
 
-export const Step = <Steps extends NonEmptyArray<string>>({ onEnter, children }: StepProps<Steps>) => {
+export const Step = <Steps extends StepsType>({ onEnter, children }: StepProps<Steps>) => {
   useEffect(() => {
     onEnter?.();
   }, [onEnter]);

--- a/packages/react/use-funnel/src/models.ts
+++ b/packages/react/use-funnel/src/models.ts
@@ -1,2 +1,4 @@
+import { NonEmptyArray } from '@toss/utils';
+
 /** @tossdocs-ignore */
-export type NonEmptyArray<T> = readonly [T, ...T[]];
+export type StepsType = Readonly<NonEmptyArray<string>>;

--- a/packages/react/use-funnel/src/useFunnel.tsx
+++ b/packages/react/use-funnel/src/useFunnel.tsx
@@ -9,7 +9,7 @@ import { useRouter } from 'next/router.js';
 import { SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from 'react-query';
 import { Funnel, FunnelProps, Step, StepProps } from './Funnel';
-import { NonEmptyArray } from './models';
+import { StepsType } from './models';
 
 interface SetStepOptions {
   stepChangeType?: 'push' | 'replace';
@@ -17,15 +17,15 @@ interface SetStepOptions {
   query?: Record<string, any>;
 }
 
-type RouteFunnelProps<Steps extends NonEmptyArray<string>> = Omit<FunnelProps<Steps>, 'steps' | 'step'>;
+type RouteFunnelProps<Steps extends StepsType> = Omit<FunnelProps<Steps>, 'steps' | 'step'>;
 
-type FunnelComponent<Steps extends NonEmptyArray<string>> = ((props: RouteFunnelProps<Steps>) => JSX.Element) & {
+type FunnelComponent<Steps extends StepsType> = ((props: RouteFunnelProps<Steps>) => JSX.Element) & {
   Step: (props: StepProps<Steps>) => JSX.Element;
 };
 
 const DEFAULT_STEP_QUERY_KEY = 'funnel-step';
 
-export const useFunnel = <Steps extends NonEmptyArray<string>>(
+export const useFunnel = <Steps extends StepsType>(
   steps: Steps,
   options?: {
     /**
@@ -40,14 +40,14 @@ export const useFunnel = <Steps extends NonEmptyArray<string>>(
   withState: <StateExcludeStep extends Record<string, unknown> & { step?: never }>(
     initialState: StateExcludeStep
   ) => [
-      FunnelComponent<Steps>,
-      StateExcludeStep,
-      (
-        next:
-          | Partial<StateExcludeStep & { step: Steps[number] }>
-          | ((next: Partial<StateExcludeStep & { step: Steps[number] }>) => StateExcludeStep & { step: Steps[number] })
-      ) => void
-    ];
+    FunnelComponent<Steps>,
+    StateExcludeStep,
+    (
+      next:
+        | Partial<StateExcludeStep & { step: Steps[number] }>
+        | ((next: Partial<StateExcludeStep & { step: Steps[number] }>) => StateExcludeStep & { step: Steps[number] })
+    ) => void
+  ];
 } => {
   const router = useRouter();
   const stepQueryKey = options?.stepQueryKey ?? DEFAULT_STEP_QUERY_KEY;
@@ -164,14 +164,14 @@ export const useFunnel = <Steps extends NonEmptyArray<string>>(
     withState: <StateExcludeStep extends Record<string, unknown> & { step?: never }>(
       initialState: StateExcludeStep
     ) => [
-        FunnelComponent<Steps>,
-        StateExcludeStep,
-        (
-          next:
-            | Partial<StateExcludeStep & { step: Steps[number] }>
-            | ((next: Partial<StateExcludeStep & { step: Steps[number] }>) => StateExcludeStep & { step: Steps[number] })
-        ) => void
-      ];
+      FunnelComponent<Steps>,
+      StateExcludeStep,
+      (
+        next:
+          | Partial<StateExcludeStep & { step: Steps[number] }>
+          | ((next: Partial<StateExcludeStep & { step: Steps[number] }>) => StateExcludeStep & { step: Steps[number] })
+      ) => void
+    ];
   };
 };
 


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->


NonEmptyArray type already exists in @toss/util. However, a readonly property has been added to the existing NonEmptyArray type with the same name in model.ts. Although they have the same name, they have additional properties, which can cause confusion.

- The NonEmptyArray type, which was referenced in many places, has been abstracted into StepType.
- StepType can perform the same type inference as before.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
